### PR TITLE
Scale camera moves according to AABBs. Include occlusion checks

### DIFF
--- a/App/Assets/Shaders/ComputeShaders/ComposeImage.comp
+++ b/App/Assets/Shaders/ComputeShaders/ComposeImage.comp
@@ -4,7 +4,7 @@
 #extension GL_ARB_compute_variable_group_size: enable
 
 layout(std430, binding = 0) restrict readonly buffer depthBuffer {
-    uint64_t _depth[]; //Los 32 bits m�s significativos son para la profundidad, los 32 restantes para el atributo del punto.
+    uint64_t _depth[]; //Los 32 bits más significativos son para la profundidad, los 32 restantes para el atributo del punto.
 };
 
 #define NULL_BACKGROUND 0xFFFFFFFF
@@ -12,6 +12,7 @@ layout(std430, binding = 0) restrict readonly buffer depthBuffer {
 uniform vec3 firstGradientPoint;
 uniform vec3 secondGradientPoint;
 uniform vec3 lastGradientPoint;
+uniform float cameraFoV;
 
 subroutine vec3 GetColor(uint codedColor);
 subroutine uniform GetColor GetColorUniform;
@@ -61,6 +62,30 @@ bool fillBackground(ivec2 pixelCoords, ivec2 imgSize) {
 	return sum == uint8_t(8) || (m0 * m1 * m2 * m3 * m4 * m5 * m6 * m7) != uint8_t(0);
 }
 
+float getOcclusionAngle(ivec2 pixelCoords, ivec2 imgSize, float depth)
+{
+	ivec2 begin = clamp(pixelCoords - 1, ivec2(0), ivec2(imgSize) - 1);
+	ivec2 end = clamp(pixelCoords + 1, ivec2(0), ivec2(imgSize) - 1);
+	float minAngle = 0xfffffff;
+
+	for (int y = begin.y; y <= end.y; ++y) {
+		for (int x = begin.x; x <= end.x; ++x) {
+			if (x == pixelCoords.x && y == pixelCoords.y) 
+				continue;
+
+			uint tempDepthNeighbor = uint(_depth[getPixelId(ivec2(x, y), imgSize)] >> 32);
+			if (tempDepthNeighbor == ~uint(0)) 
+				continue;
+
+			float depthNeighbour = uintBitsToFloat(uint(_depth[getPixelId(ivec2(x, y), imgSize)] >> 32));
+			float widthPixel = 2.0f * max(depth, depthNeighbour) * tan(cameraFoV / float(imgSize.x));
+			minAngle = min(abs(atan(widthPixel, depth - depthNeighbour)), minAngle);
+		}
+	}
+	
+	return minAngle;
+}
+
 uniform layout(rgba8) writeonly image2D colorOutput;
 
 layout(local_size_variable) in;
@@ -74,16 +99,23 @@ void main() {
         pixelCoords.x = int(pixelIndex % imgSize.x);
         uint codedColor = uint(_depth[pixelIndex]);
         if (codedColor != NULL_BACKGROUND) {
-            vec4 color = vec4(GetColorUniform(codedColor), 1);
-            imageStore(colorOutput, pixelCoords, color);
-        } else {
+			float depth = uintBitsToFloat(uint(_depth[pixelIndex] >> 32));
+			if (getOcclusionAngle(pixelCoords, imgSize, depth) >= 0.1) {
+				vec4 color = vec4(GetColorUniform(codedColor), 1);
+				imageStore(colorOutput, pixelCoords, color);
+			}
+			else
+				codedColor = NULL_BACKGROUND;
+		}
+        
+		if (codedColor == NULL_BACKGROUND) {
             vec4 finalColor = vec4(0, 0, 0, 0);
-            const int neightbourSize = 0;
+            const int neightbourSize = 1;
             for (int x = max(pixelCoords.x - neightbourSize, 0); x <= min(pixelCoords.x + neightbourSize, imgSize.x - 1); x++) {
                 for (int y = max(pixelCoords.y - neightbourSize, 0); y <= min(pixelCoords.y + neightbourSize, imgSize.y - 1); y++) {
                     uint pixelId = y * imgSize.x + x;
                     codedColor = uint(_depth[pixelId]);
-                    if (codedColor != NULL_BACKGROUND) {
+                    if (pixelId != pixelIndex && codedColor != NULL_BACKGROUND) {
                         finalColor.xyz += GetColorUniform(codedColor);
                         finalColor.a += 1;
                     }

--- a/App/Assets/Shaders/ComputeShaders/EDL.comp
+++ b/App/Assets/Shaders/ComputeShaders/EDL.comp
@@ -4,7 +4,7 @@
 #extension GL_ARB_compute_variable_group_size: enable
 
 layout(std430, binding = 0) restrict readonly buffer depthBuffer {
-    uint64_t _depth[]; //Los 32 bits m�s significativos son para la profundidad, los 32 restantes para el atributo del punto.
+    uint64_t _depth[]; //Los 32 bits más significativos son para la profundidad, los 32 restantes para el atributo del punto.
 };
 
 uniform float zNear, zFar;

--- a/App/Assets/Shaders/ComputeShaders/ResetDepthBuffer.comp
+++ b/App/Assets/Shaders/ComputeShaders/ResetDepthBuffer.comp
@@ -6,7 +6,7 @@
 layout (local_size_variable) in;
 
 layout(std430, binding = 0) restrict buffer depthBuffer {
-	uint64_t _depth[]; //Los 32 bits m�s significativos son para la profundidad, los 32 restantes para el id del punto.
+	uint64_t _depth[]; //Los 32 bits más significativos son para la profundidad, los 32 restantes para el id del punto.
 };
 
 uniform vec3 backgroundColor;

--- a/Core/Source/Camera/Camera.h
+++ b/Core/Source/Camera/Camera.h
@@ -56,6 +56,10 @@ namespace Nimbus {
 		{
 			return _properties._zFar;
 		}
+		float getFoV() const
+		{
+			return _properties._fovX;
+		}
 
 		void saveCamera();
 		void setBottomLeftCorner(const vec2& bottomLeft);

--- a/Core/Source/DataTypes/Geometry/AABB.h
+++ b/Core/Source/DataTypes/Geometry/AABB.h
@@ -12,6 +12,8 @@ public:
 	AABB(const AABB& aabb);
 	~AABB();
 	AABB& operator=(const AABB& aabb);
+	bool operator==(const AABB& aabb) const { return _min == aabb._min && _max == aabb._max; }
+	bool operator!=(const AABB& aabb) const { return !(*this == aabb); }
 
 	dvec3 center() const { return (_max + _min) / 2.0; }
 	AABB dot(const mat4& matrix) const;

--- a/Core/Source/Graphics/Renderer.cpp
+++ b/Core/Source/Graphics/Renderer.cpp
@@ -178,8 +178,8 @@ void Nimbus::Renderer::prepareOpenGL(u16 width, u16 height, ApplicationState* ap
 
 	// Observer
 	InputManager* inputManager = InputManager::getInstance();
-	inputManager->suscribeResize(this);
-	inputManager->suscribeScreenshot(this);
+	inputManager->subscribeResize(this);
+	inputManager->subscribeScreenshot(this);
 
 	_fileWatcher.addWatch("Assets/Shaders/ComputeShaders", this);
 	_fileWatcher.watch();
@@ -526,6 +526,7 @@ void Nimbus::Renderer::render() {
 						_composeImageShader->setUniform("firstGradientPoint", first);
 						_composeImageShader->setUniform("secondGradientPoint", second);
 						_composeImageShader->setUniform("lastGradientPoint", last);
+						_composeImageShader->setUniform("cameraFoV", getCamera()->getFoV());
 						if (cloud->_attToUse == Attribute::RGB)
 							_composeImageShader->setSubroutineUniform(ShaderEnum::COMPUTE_SHADER, ShaderEnum::GET_COLOR, "getColorUnpackingUint");
 						else
@@ -620,6 +621,7 @@ unsigned Nimbus::Renderer::addModel(Model3D* model) {
 		pointCloud->_name += idAppend;
 
 		_scenes[_activeScene]->_pointClouds.insert(std::make_pair(pointCloud->getName(), std::unique_ptr<PointCloud>(pointCloud)));
+		InputManager::getInstance()->updateMovementSteps();
 
 		getCamera()->changed = true;
 		return _scenes[_activeScene]->_pointClouds.size() - 1;

--- a/Core/Source/Graphics/Renderer.h
+++ b/Core/Source/Graphics/Renderer.h
@@ -92,7 +92,6 @@ namespace Nimbus {
 
 		// - Deleters
 		void deletePointCloud(const std::string& cloudName) const; // deleteModel 
-		void deleteTriangleMesh(const std::string& meshName) const;
 		void deleteLight(unsigned lightIdx) const;
 		void deleteCamera(unsigned cameraIdx) const;
 		bool deleteScene();
@@ -105,7 +104,7 @@ namespace Nimbus {
 		std::string getSceneCompleteName() const { return _scenes[_activeScene]->_scenePath + "/" + _scenes[_activeScene]->_sceneName; }
 		std::string getSceneName() const { return _scenes[_activeScene]->_sceneName; }
 		unsigned getCurrentActiveScene() const { return _activeScene; }
-		Scene* getActiveScene() const { return _scenes[_activeScene].get(); }
+		Scene* getActiveScene() const { return _activeScene >= _scenes.size() ? nullptr : _scenes[_activeScene].get(); }
 		ApplicationState* getAppState() const {
 			return _appState;
 		}

--- a/Core/Source/Managers/InputManager.cpp
+++ b/Core/Source/Managers/InputManager.cpp
@@ -10,6 +10,8 @@
 #define GLFW_EXPOSE_NATIVE_WIN32
 #include <GLFW/glfw3native.h>
 
+#include <algorithm>
+
 #include "IO/FileManager.h"
 
 
@@ -108,26 +110,13 @@ const vec2 Nimbus::InputManager::_defaultCursorPosition = vec2(-1.0f, -1.0f);
 // Public methods
 
 Nimbus::InputManager::InputManager() : _lastCursorPosition(_defaultCursorPosition), _leftClickPressed(false), _rightClickPressed(false), _scrollClickPressed(false) {
-	this->buildMoveRelatedBuffers();
+	this->buildMovementBuffers();
+	this->updateMovementSteps();
 }
 
-void Nimbus::InputManager::buildMoveRelatedBuffers() {
-	_movementMultiplier = 7.0f;
-	_moveSpeedUp = 1.0f;
-
-	_moveSpeed = std::vector<float>(static_cast<size_t>(NUM_EVENTS), .0f);
-	_moveSpeed[BOOM] = 0.05f;
-	_moveSpeed[DOLLY] = 0.1f;
-	_moveSpeed[ORBIT_XZ] = 0.08f;
-	_moveSpeed[ORBIT_Y] = 0.07f;
-	_moveSpeed[PAN] = 0.03f;
-	_moveSpeed[TILT] = 0.03f;
-	_moveSpeed[TRUCK] = 0.03f;
-	_moveSpeed[ZOOM] = 0.01f;
-	_moveSpeed[ROTATION] = 0.8f;
-
-	_eventKey = std::vector<ivec2>(static_cast<size_t>(NUM_EVENTS), ivec2(0));
-
+void Nimbus::InputManager::buildMovementBuffers()
+{
+	_eventKey = std::vector(NUM_EVENTS, ivec2(0));
 	_eventKey[BOOM] = ivec2(GLFW_KEY_UP, GLFW_KEY_DOWN);
 	_eventKey[DOLLY] = ivec2(GLFW_KEY_W, GLFW_KEY_S);
 	_eventKey[DOLLY_SPEED_UP] = ivec2(GLFW_MOD_SHIFT);
@@ -140,8 +129,6 @@ void Nimbus::InputManager::buildMoveRelatedBuffers() {
 	_eventKey[TRUCK] = ivec2(GLFW_KEY_D, GLFW_KEY_A);
 	_eventKey[ROTATION] = ivec2(GLFW_KEY_Q, GLFW_KEY_E);
 	_eventKey[zoomOutAnim] = ivec2(GLFW_KEY_1);
-
-	_moves = std::vector<uint32_t>(static_cast<size_t>(NUM_EVENTS), 0);
 }
 
 bool Nimbus::InputManager::mouseMovement(const float xPos, const float yPos) {
@@ -257,19 +244,54 @@ void Nimbus::InputManager::init(GLFWwindow* window) {
 	glfwSetWindowSizeLimits(window, 200, 200, GLFW_DONT_CARE, GLFW_DONT_CARE);
 }
 
-void Nimbus::InputManager::suscribeResize(ResizeListener* listener) {
+void Nimbus::InputManager::updateMovementSteps() {
+	_movementMultiplier = 1.0;
+	_moveSpeedUp = 1.0f;
+
+	// Calculate the movement speed based on the scene dimensions
+	Renderer* renderer = Renderer::getInstance();
+	if (renderer->getActiveScene())
+	{
+		AABB aabb;
+		for (auto& pointCloud : renderer->getActiveScene()->_pointClouds | std::views::values)
+			aabb.update(pointCloud->getAABB());
+
+		if (aabb != AABB())
+		{
+			const vec3 aabbDim = aabb.size();
+			const float size = std::sqrt(aabbDim.x * aabbDim.x + aabbDim.y * aabbDim.y + aabbDim.z * aabbDim.z);
+
+			_movementMultiplier = std::log(size + 1.0f) / 2.0f;
+		}
+	}
+
+	_moveSpeed = std::vector<float>(static_cast<size_t>(NUM_EVENTS), .0f);
+	_moveSpeed[BOOM] = 0.05f * _movementMultiplier;
+	_moveSpeed[DOLLY] = 0.1f * _movementMultiplier;
+	_moveSpeed[ORBIT_XZ] = 0.08f * _movementMultiplier;
+	_moveSpeed[ORBIT_Y] = 0.07f * _movementMultiplier;
+	_moveSpeed[PAN] = 0.03f * _movementMultiplier;
+	_moveSpeed[TILT] = 0.03f * _movementMultiplier;
+	_moveSpeed[TRUCK] = 0.03f * _movementMultiplier;
+	_moveSpeed[ZOOM] = 0.01f * _movementMultiplier;
+	_moveSpeed[ROTATION] = 2.0f * _movementMultiplier;
+
+	_moves = std::vector<uint32_t>(static_cast<size_t>(NUM_EVENTS), 0);
+}
+
+void Nimbus::InputManager::subscribeResize(ResizeListener* listener) {
 	_resizeListeners.push_back(listener);
 }
 
-void Nimbus::InputManager::suscribeScreenshot(ScreenshotListener* listener) {
+void Nimbus::InputManager::subscribeScreenshot(ScreenshotListener* listener) {
 	_screenshotListeners.push_back(listener);
 }
 
-void Nimbus::InputManager::suscribeMouseButton(MouseButtonListener* listener) {
+void Nimbus::InputManager::subscribeMouseButton(MouseButtonListener* listener) {
 	_mouseButtonListeners.push_back(listener);
 }
 
-void Nimbus::InputManager::unsuscribeMouseButton(const MouseButtonListener* listener) {
+void Nimbus::InputManager::unsubscribeMouseButton(const MouseButtonListener* listener) {
 	bool found = false;
 	size_t lFound = 0;
 	for (lFound = 0; lFound < _mouseButtonListeners.size() && !found; ++lFound) {
@@ -281,11 +303,11 @@ void Nimbus::InputManager::unsuscribeMouseButton(const MouseButtonListener* list
 	}
 }
 
-void Nimbus::InputManager::suscribeMouseMove(MouseMoveListener* listener) {
+void Nimbus::InputManager::subscribeMouseMove(MouseMoveListener* listener) {
 	_mouseDragListeners.push_back(listener);
 }
 
-void Nimbus::InputManager::unsuscribeMouseMove(const MouseMoveListener* listener) {
+void Nimbus::InputManager::unsubscribeMouseMove(const MouseMoveListener* listener) {
 	bool found = false;
 	size_t lFound = 0;
 	for (lFound = 0; lFound < _mouseDragListeners.size() && !found; ++lFound) {

--- a/Core/Source/Managers/InputManager.h
+++ b/Core/Source/Managers/InputManager.h
@@ -68,7 +68,7 @@ namespace Nimbus {
 
 	private:
 		InputManager();
-		void buildMoveRelatedBuffers();
+		void buildMovementBuffers();
 		bool mouseMovement(float xPos, float yPos);
 		void processPressedKeyEvent(int key, int mods);
 		void processReleasedKeyEvent(int key, int mods);
@@ -85,14 +85,15 @@ namespace Nimbus {
 		virtual ~InputManager();
 		static ApplicationState* getApplicationState() { return &_applicationState; }
 		void init(GLFWwindow* window);
+		void updateMovementSteps();
 
 	public:
-		void suscribeResize(ResizeListener* listener);
-		void suscribeScreenshot(ScreenshotListener* listener);
-		void suscribeMouseButton(MouseButtonListener* listener);
-		void unsuscribeMouseButton(const MouseButtonListener* listener);
-		void suscribeMouseMove(MouseMoveListener* listener);
-		void unsuscribeMouseMove(const MouseMoveListener* listener);
+		void subscribeResize(ResizeListener* listener);
+		void subscribeScreenshot(ScreenshotListener* listener);
+		void subscribeMouseButton(MouseButtonListener* listener);
+		void unsubscribeMouseButton(const MouseButtonListener* listener);
+		void subscribeMouseMove(MouseMoveListener* listener);
+		void unsubscribeMouseMove(const MouseMoveListener* listener);
 	};
 }
 


### PR DESCRIPTION
- The camera is now moved with a step size according to the scene AABB.
- Occlusion checks has been added in ComposeImage shader. It requires the camera's FOV to calculate the pixel size in meters.